### PR TITLE
specify dependency on systemd-units for >=rhel7/fedora16

### DIFF
--- a/couchdb.spec
+++ b/couchdb.spec
@@ -39,6 +39,10 @@ BuildRequires:  libtool
 # For /usr/bin/prove
 BuildRequires:  perl(Test::Harness)
 
+%if 0%{?fedora} > 16 || 0%{?rhel} >= 7
+BuildRequires: systemd-units
+%endif
+
 Requires:    erlang-asn1%{?_isa}
 Requires:    erlang-erts%{?_isa} >= R13B
 Requires:    erlang-os_mon%{?_isa}


### PR DESCRIPTION
Fix build on centos 7, it would fail with the error mentioned here  https://lists.fedoraproject.org/pipermail/devel/2011-November/160100.html
